### PR TITLE
crossword: treat blank squares as blocks for clue numbering

### DIFF
--- a/crossword/format_puz.py
+++ b/crossword/format_puz.py
@@ -28,17 +28,17 @@ def from_puz(puzzle):
         rows.append(puzzle.solution[i:i + puzzle.width])
 
     def is_across(x, y):
-        if result[x, y].solution == '.':
+        if result[x, y].solution in ':.':
             return False
-        start = x == 0 or (0 <= x - 1 and result[x - 1, y].solution == '.')
-        end = (x + 1 < puzzle.width and result[x + 1, y].solution != '.')
+        start = x == 0 or (0 <= x - 1 and result[x - 1, y].solution in ':.')
+        end = (x + 1 < puzzle.width and result[x + 1, y].solution not in ':.')
         return start and end
 
     def is_down(x, y):
-        if result[x, y].solution == '.':
+        if result[x, y].solution in ':.':
             return False
-        start = y == 0 or (y - 1 >= 0 and result[x, y - 1].solution == '.')
-        end = (y + 1 < puzzle.height and result[x, y + 1].solution != '.')
+        start = y == 0 or (y - 1 >= 0 and result[x, y - 1].solution in ':.')
+        end = (y + 1 < puzzle.height and result[x, y + 1].solution not in ':.')
         return start and end
 
     for y, row in enumerate(rows):


### PR DESCRIPTION
Upstreaming a fix from https://github.com/century-arcade/xd, which vendors a copy of this library. See https://github.com/century-arcade/xd/commit/dc5a6cf12c396b4c4716b73079da0174e3e07d41 and https://github.com/century-arcade/xd/issues/63 for reference.